### PR TITLE
fix($attributes): make <style module> behave accurately

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -25,6 +25,12 @@ module.exports = function (content) {
   if (parts.styles.length) {
     let hasModules = false
     parts.styles.forEach(function (style, i) {
+      // compensate for the fact that HTML-link strings are parsed incorrectly in react-vue-loader
+      // when the presence of an attribute is used to indicate true, eg:
+      // <style module>
+      style.module = !!(style.attrs && style.attrs[':module'])
+      style.scoped = !!(style.attrs && style.attrs[':scoped'])
+      
       // require style
       let requireString = getRequire('styles', style, i, style.scoped)
       if (style.scoped === true) {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -25,12 +25,6 @@ module.exports = function (content) {
   if (parts.styles.length) {
     let hasModules = false
     parts.styles.forEach(function (style, i) {
-      // compensate for the fact that HTML-link strings are parsed incorrectly in react-vue-loader
-      // when the presence of an attribute is used to indicate true, eg:
-      // <style module>
-      style.module = !!(style.attrs && style.attrs[':module'])
-      style.scoped = !!(style.attrs && style.attrs[':scoped'])
-      
       // require style
       let requireString = getRequire('styles', style, i, style.scoped)
       if (style.scoped === true) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -23,6 +23,15 @@ module.exports = function (content, filename, needMap) {
       content: ''
     }
   }
+  if (output.styles) {
+    output.styles.forEach(style => {
+      // compensate for the fact that HTML-link strings are parsed incorrectly in react-vue-loader
+      // when the presence of an attribute is used to indicate true, eg:
+      // <style module>
+      style.module = !!(style.attrs && style.attrs[':module'])
+      style.scoped = !!(style.attrs && style.attrs[':scoped'])
+    })
+  }
   if (needMap) {
     if (output.script && !output.script.src) {
       output.script.map = generateSourceMap(


### PR DESCRIPTION
Currently truthy attributes without values, such as `<style module>`, are not parsed correctly. So this is an override that discovers when `module` or `scoped` is used as an attribute. 